### PR TITLE
chore: Turn off server signature

### DIFF
--- a/sites-available/000-default.conf
+++ b/sites-available/000-default.conf
@@ -32,6 +32,10 @@
 # See also: https://httpd.apache.org/docs/current/mod/core.html#serversignature
 ServerSignature Off
 
+# Hide any specific versions in server header
+# See also: https://httpd.apache.org/docs/current/mod/core.html#servertokens
+ServerTokens Prod
+
 <Directory /var/www/html>
         <IfModule mod_rewrite.c>
                 RewriteEngine On

--- a/sites-available/000-default.conf
+++ b/sites-available/000-default.conf
@@ -28,6 +28,10 @@
         #Include conf-available/serve-cgi-bin.conf
 </VirtualHost>
 
+# Disable server signature
+# See also: https://httpd.apache.org/docs/current/mod/core.html#serversignature
+ServerSignature Off
+
 <Directory /var/www/html>
         <IfModule mod_rewrite.c>
                 RewriteEngine On


### PR DESCRIPTION
Fixes #5 

Testing locally with the existing settings, accessing a resource that doesn't exist

``` bash
curl -XGET http\://localhost\:80/hello.txt
```

returns 404 with the following content

``` html
<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
<html><head>
<title>404 Not Found</title>
</head><body>
<h1>Not Found</h1>
<p>The requested URL was not found on this server.</p>
<hr>
<address>Apache/2.4.52 (Ubuntu) Server at localhost Port 8080</address>
</body></html>
```

However, with `ServerSignature Off` explicitly set, it returns

``` html
<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
<html><head>
<title>404 Not Found</title>
</head><body>
<h1>Not Found</h1>
<p>The requested URL was not found on this server.</p>
</body></html>
```

without

``` html
<hr>
<address>Apache/2.4.52 (Ubuntu) Server at localhost Port 8080</address>
```

It appears to me that `ServerSignature` wasn't `Off` before, even though that is the default value according to <https://httpd.apache.org/docs/current/mod/core.html#serversignature>.

``` text
Default:  ServerSignature Off
```

If the issue persists after this change, we may need to configure custom error responses for 403, 404, etc. See also: <https://httpd.apache.org/docs/current/custom-error.html>

P.S. The second commit is only optional, as in our case, it's going to be `server: cloudflare` in the response header. It's a good practice nonetheless.

EDIT: Syntax highlight for HTML blocks.