### PR TITLE
chore: Block access to xmlrpc.php

### DIFF
--- a/sites-available/000-default.conf
+++ b/sites-available/000-default.conf
@@ -36,6 +36,11 @@ ServerSignature Off
 # See also: https://httpd.apache.org/docs/current/mod/core.html#servertokens
 ServerTokens Prod
 
+# Block access to xmlrpc.php
+<Files xmlrpc.php>
+        Require all denied
+</Files>
+
 <Directory /var/www/html>
         <IfModule mod_rewrite.c>
                 RewriteEngine On


### PR DESCRIPTION
Fixes #6 

Testing

``` bash
curl -XPOST http\://localhost\:80/xmlrpc.php
```

locally gives me

``` html
<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
<html><head>
<title>403 Forbidden</title>
</head><body>
<h1>Forbidden</h1>
<p>You don't have permission to access this resource.</p>
</body></html>
```

now.