### PR TITLE
chore: Set ServerAdmin

### DIFF
--- a/sites-available/000-default.conf
+++ b/sites-available/000-default.conf
@@ -8,7 +8,7 @@
         # However, you must set it for any further virtual host explicitly.
         #ServerName www.example.com
 
-        ServerAdmin webmaster@localhost
+        ServerAdmin ietf-action@ietf.org
         DocumentRoot /var/www/html
 
         # Available loglevels: trace8, ..., trace1, debug, info, notice, warn,


### PR DESCRIPTION
Fixes #9 

It was previously set to help at amsl dot com for trustee, but the ietf dot org email address appears to be the more common one to use. 

I'm not certain that this directive is actually being used unless `ServerSignature` is set to `Email` (which won't be the case - see https://github.com/ietf-tools/trustee-proxyenv/pull/7 and https://httpd.apache.org/docs/current/mod/core.html#serversignature), but overriding the default value seems sensible to me.